### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@
 from mycroft import MycroftSkill, intent_file_handler
 from mycroft.util.format import nice_date, nice_time
 from mycroft.util.log import LOG
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from mattermostdriver import Driver
 import mattermostdriver.exceptions as mme
 from datetime import datetime
@@ -129,11 +129,13 @@ class MycroftChat(MycroftSkill):
         best_score = 66  # minimum score required
         for chan in self._get_channel_info():
             score = fuzz.ratio(channel_name.lower(),
-                               chan['display_name'].lower())
+                               chan['display_name'].lower(),
+                               score_cutoff=best_score)
             # LOG.debug("{}->{}".format(unr['display_name'], score))
             if score > best_score:
                 best_chan = chan
                 best_score = score
+
         LOG.debug("{} -> {}".format(best_chan, best_score))
         if not best_chan:
             self.speak_dialog('channel.unknown',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 mattermostdriver>=6.1.1
-fuzzywuzzy>=0.14.0
-python-Levenshtein>=0.12.0
+rapidfuzz>=0.7.6


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy